### PR TITLE
add checkbox for commands replay previous next

### DIFF
--- a/core/class/mode.class.php
+++ b/core/class/mode.class.php
@@ -34,60 +34,73 @@ class mode extends eqLogic {
 	}
 
 	public function postSave() {
+		$i = 0;
+
 		$lockState = $this->getCmd(null, 'lock_state');
-		if (!is_object($lockState)) {
-			$lockState = new modeCmd();
-			$lockState->setEqLogic_id($this->getId());
-			$lockState->setLogicalId('lock_state');
-			$lockState->setName(__('Verrouillage', __FILE__));
-			$lockState->setTemplate('dashboard', 'lock');
-			$lockState->setTemplate('mobile', 'lock');
-			$lockState->setIsVisible(0);
+		if ($this->getConfiguration('showLockCmd') == 1) {
+			if (!is_object($lockState)) {
+				$lockState = new modeCmd();
+				$lockState->setEqLogic_id($this->getId());
+				$lockState->setLogicalId('lock_state');
+				$lockState->setName(__('Verrouillage', __FILE__));
+				$lockState->setTemplate('dashboard', 'lock');
+				$lockState->setTemplate('mobile', 'lock');
+				$lockState->setIsVisible(0);
+			}
+			$lockState->setType('info');
+			$lockState->setSubType('binary');
+			$lockState->setOrder($i);
+			$i++;
+			$lockState->save();
+		} else {
+			if (is_object($lockState)) {
+				$lockState->remove();
+			}
 		}
-		$lockState->setType('info');
-		$lockState->setSubType('binary');
-		$lockState->setOrder(0);
-		$lockState->save();
 
 		$lock = $this->getCmd(null, 'lock');
-		if (!is_object($lock)) {
-			$lock = new modeCmd();
-			$lock->setEqLogic_id($this->getId());
-			$lock->setLogicalId('lock');
-			$lock->setName(__('Verrouiller', __FILE__));
-			$lock->setTemplate('dashboard', 'lock');
-			$lock->setTemplate('mobile', 'lock');
-		}
-		$lock->setType('action');
-		$lock->setSubType('other');
 		if ($this->getConfiguration('showLockCmd') == 1) {
-			$lock->setIsVisible(1);
+			if (!is_object($lock)) {
+				$lock = new modeCmd();
+				$lock->setEqLogic_id($this->getId());
+				$lock->setLogicalId('lock');
+				$lock->setName(__('Verrouiller', __FILE__));
+				$lock->setTemplate('dashboard', 'lock');
+				$lock->setTemplate('mobile', 'lock');
+			}
+			$lock->setType('action');
+			$lock->setSubType('other');
+			$lock->setOrder($i);
+			$i++;
+			$lock->setValue($lockState->getId());
+			$lock->save();
 		} else {
-			$lock->setIsVisible(0);
+			if (is_object($lock)) {
+				$lock->remove();
+			}
 		}
-		$lock->setOrder(1);
-		$lock->setValue($lockState->getId());
-		$lock->save();
 
 		$unlock = $this->getCmd(null, 'unlock');
-		if (!is_object($unlock)) {
-			$unlock = new modeCmd();
-			$unlock->setEqLogic_id($this->getId());
-			$unlock->setLogicalId('unlock');
-			$unlock->setName(__('Déverrouiller', __FILE__));
-			$unlock->setTemplate('dashboard', 'lock');
-			$unlock->setTemplate('mobile', 'lock');
-		}
-		$unlock->setType('action');
-		$unlock->setSubType('other');
 		if ($this->getConfiguration('showLockCmd') == 1) {
-			$unlock->setIsVisible(1);
+			if (!is_object($unlock)) {
+				$unlock = new modeCmd();
+				$unlock->setEqLogic_id($this->getId());
+				$unlock->setLogicalId('unlock');
+				$unlock->setName(__('Déverrouiller', __FILE__));
+				$unlock->setTemplate('dashboard', 'lock');
+				$unlock->setTemplate('mobile', 'lock');
+			}
+			$unlock->setType('action');
+			$unlock->setSubType('other');
+			$unlock->setOrder($i);
+			$i++;
+			$unlock->setValue($lockState->getId());
+			$unlock->save();
 		} else {
-			$unlock->setIsVisible(0);
+			if (is_object($unlock)) {
+				$unlock->remove();
+			}
 		}
-		$unlock->setOrder(2);
-		$unlock->setValue($lockState->getId());
-		$unlock->save();
 
 		$currentMode = $this->getCmd(null, 'currentMode');
 		if (!is_object($currentMode)) {
@@ -101,7 +114,8 @@ class mode extends eqLogic {
 		$currentMode->setType('info');
 		$currentMode->setSubType('string');
 		$currentMode->setDisplay('generic_type', 'MODE_STATE');
-		$currentMode->setOrder(3);
+		$currentMode->setOrder($i);
+		$i++;
 		$currentMode->save();
 
 		$previousMode = $this->getCmd(null, 'previousMode');
@@ -116,57 +130,75 @@ class mode extends eqLogic {
 		}
 		$previousMode->setType('info');
 		$previousMode->setSubType('string');
-		$previousMode->setOrder(4);
+		$previousMode->setDisplay('generic_type', 'DONT');
+		$previousMode->setOrder($i);
+		$i++;
 		$previousMode->save();
 
 		$replay = $this->getCmd(null, 'replay');
-		if (!is_object($replay)) {
-			$replay = new modeCmd();
-			$replay->setEqLogic_id($this->id);
-			$replay->setLogicalId('replay');
-			$replay->setName(__('Rejouer', __FILE__));
-			$replay->setDisplay('icon', '<i class="fas fa-redo"></i>');
-			$replay->setIsVisible(0);
+		if ($this->getConfiguration('showReplayCmd') == 1) {
+			if (!is_object($replay)) {
+				$replay = new modeCmd();
+				$replay->setEqLogic_id($this->id);
+				$replay->setLogicalId('replay');
+				$replay->setName(__('Rejouer', __FILE__));
+				$replay->setDisplay('icon', '<i class="fas fa-redo"></i>');
+			}
+			$replay->setType('action');
+			$replay->setSubType('other');
+			$replay->setDisplay('generic_type', 'MODE_SET_STATE');
+			$replay->setOrder($i);
+			$i++;
+			$replay->save();
+		} else {
+			if (is_object($replay)) {
+				$replay->remove();
+			}
 		}
-		$replay->setType('action');
-		$replay->setSubType('other');
-		$replay->setDisplay('generic_type', 'MODE_SET_STATE');
-		$replay->setOrder(5);
-		$replay->save();
 
 		$returnPreviousMode = $this->getCmd(null, 'returnPreviousMode');
-		if (!is_object($returnPreviousMode)) {
-			$returnPreviousMode = new modeCmd();
-			$returnPreviousMode->setEqLogic_id($this->id);
-			$returnPreviousMode->setLogicalId('returnPreviousMode');
-			$returnPreviousMode->setName(__('Retour mode précédent', __FILE__));
-			$returnPreviousMode->setDisplay('icon', '<i class="fas fa-backward"></i>');
-			$returnPreviousMode->setIsVisible(0);
+		if ($this->getConfiguration('showPreviousCmd') == 1) {
+			if (!is_object($returnPreviousMode)) {
+				$returnPreviousMode = new modeCmd();
+				$returnPreviousMode->setEqLogic_id($this->id);
+				$returnPreviousMode->setLogicalId('returnPreviousMode');
+				$returnPreviousMode->setName(__('Retour mode précédent', __FILE__));
+				$returnPreviousMode->setDisplay('icon', '<i class="fas fa-backward"></i>');
+			}
+			$returnPreviousMode->setType('action');
+			$returnPreviousMode->setSubType('other');
+			$returnPreviousMode->setDisplay('generic_type', 'MODE_SET_STATE');
+			$returnPreviousMode->setOrder($i);
+			$i++;
+			$returnPreviousMode->save();
+		} else {
+			if (is_object($returnPreviousMode)) {
+				$returnPreviousMode->remove();
+			}
 		}
-		$returnPreviousMode->setType('action');
-		$returnPreviousMode->setSubType('other');
-		$returnPreviousMode->setDisplay('generic_type', 'MODE_SET_STATE');
-		$returnPreviousMode->setOrder(6);
-		$returnPreviousMode->save();
 
 		$gotoNextMode = $this->getCmd(null, 'nextMode');
-		if (!is_object($gotoNextMode)) {
-			$gotoNextMode = new modeCmd();
-			$gotoNextMode->setEqLogic_id($this->id);
-			$gotoNextMode->setLogicalId('nextMode');
-			$gotoNextMode->setName(__('Aller au mode suivant', __FILE__));
-			$gotoNextMode->setDisplay('icon', '<i class="fas fa-forward"></i>');
-			$gotoNextMode->setIsVisible(0);
+		if ($this->getConfiguration('showNextCmd') == 1) {
+			if (!is_object($gotoNextMode)) {
+				$gotoNextMode = new modeCmd();
+				$gotoNextMode->setEqLogic_id($this->id);
+				$gotoNextMode->setLogicalId('nextMode');
+				$gotoNextMode->setName(__('Aller au mode suivant', __FILE__));
+				$gotoNextMode->setDisplay('icon', '<i class="fas fa-forward"></i>');
+			}
+			$gotoNextMode->setType('action');
+			$gotoNextMode->setSubType('other');
+			$gotoNextMode->setDisplay('generic_type', 'MODE_SET_STATE');
+			$gotoNextMode->setOrder(99);
+			$gotoNextMode->save();
+		} else {
+			if (is_object($gotoNextMode)) {
+				$gotoNextMode->remove();
+			}
 		}
-		$gotoNextMode->setType('action');
-		$gotoNextMode->setSubType('other');
-		$gotoNextMode->setDisplay('generic_type', 'MODE_SET_STATE');
-		$gotoNextMode->setOrder(99);
-		$gotoNextMode->save();
 
 		$existing_mode = array();
 		if (is_array($this->getConfiguration('modes'))) {
-			$i = 7;
 			foreach (array_values($this->getConfiguration('modes')) as $value) {
 				$existing_mode[] = $value['name'];
 				if (!isset($value['renamed'])) {

--- a/desktop/php/mode.php
+++ b/desktop/php/mode.php
@@ -117,10 +117,34 @@ $eqLogics = eqLogic::byType($plugin->getId());
 							<legend><i class="fas fa-cogs"></i> {{Paramètres spécifiques}}</legend>
 							<div class="form-group">
 								<label class="col-sm-4 control-label">{{Commande de verrouillage}}
-									<sup><i class="fas fa-question-circle tooltips" title="{{Cocher la case pour afficher la commande de verrouillage sur le widget}}"></i></sup>
+									<sup><i class="fas fa-question-circle tooltips" title="{{Cocher la case pour creer la commande de verrouillage sur le widget}}"></i></sup>
 								</label>
 								<div class="col-sm-6">
 									<input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="showLockCmd">
+								</div>
+							</div>
+							<div class="form-group">
+								<label class="col-sm-4 control-label">{{Commande rejouer}}
+									<sup><i class="fas fa-question-circle tooltips" title="{{Cocher la case pour creer la commande rejouer sur le widget}}"></i></sup>
+								</label>
+								<div class="col-sm-6">
+									<input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="showReplayCmd">
+								</div>
+							</div>
+							<div class="form-group">
+								<label class="col-sm-4 control-label">{{Commande mode précédent}}
+									<sup><i class="fas fa-question-circle tooltips" title="{{Cocher la case pour creer la commande mode précédent sur le widget}}"></i></sup>
+								</label>
+								<div class="col-sm-6">
+									<input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="showPreviousCmd">
+								</div>
+							</div>
+							<div class="form-group">
+								<label class="col-sm-4 control-label">{{Commande mode suivant}}
+									<sup><i class="fas fa-question-circle tooltips" title="{{Cocher la case pour creer la commande mode suivant sur le widget}}"></i></sup>
+								</label>
+								<div class="col-sm-6">
+									<input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="showNextCmd">
 								</div>
 							</div>
 						</div>

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -20,14 +20,13 @@ require_once dirname(__FILE__) . '/../../../core/php/core.inc.php';
 
 function mode_update() {
 	foreach (mode::byType('mode') as $mode) {
+		is_object($mode->getCmd(null, 'lock_state')) && $mode->setConfiguration('showLockCmd', '1');
+		is_object($mode->getCmd(null, 'lock')) && $mode->setConfiguration('showLockCmd', '1');
+		is_object($mode->getCmd(null, 'unlock')) && $mode->setConfiguration('showLockCmd', '1');
+		is_object($mode->getCmd(null, 'replay')) && $mode->setConfiguration('showReplayCmd', '1');
+		is_object($mode->getCmd(null, 'returnPreviousMode')) && $mode->setConfiguration('showPreviousCmd', '1');
+		is_object($mode->getCmd(null, 'nextMode')) && $mode->setConfiguration('showNextCmd', '1');
 		$mode->save();
-		
-		$previousMode = $mode->getCmd(null, 'previousMode');
-		if(is_object($previousMode)){
-			$previousMode->setDisplay('generic_type', 'DONT');
-			$previousMode->setGeneric_type('DONT');
-			$previousMode->save();
-		}
 	}
 }
 ?>


### PR DESCRIPTION
this PR add checkboxs for commands replay, previous and next similar to lock
with this news PR the command is created when requested to avoid plenty of useless commands in jeedom but also out of jeedom (example useless modes in Alexa through ash plugin)